### PR TITLE
Enable board state sync via sockets

### DIFF
--- a/frontend/src/game/uiControls.js
+++ b/frontend/src/game/uiControls.js
@@ -14,7 +14,11 @@ export function initUIControls({
   deleteTokenBtn.addEventListener("click", () => {
     console.log("Delete button clicked");
     if (canvasAPI && typeof canvasAPI.removeSelectedToken === "function") {
-      canvasAPI.removeSelectedToken();
+      const tok = canvasAPI.getSelectedToken();
+      if (tok) {
+        canvasAPI.removeSelectedToken();
+        socket.emit('removeToken', { lobbyId, id: tok.id }, () => {});
+      }
     } else {
       console.error("canvasAPI.removeSelectedToken is not a function");
     }


### PR DESCRIPTION
## Summary
- handle token updates on canvas
- emit and receive token state over websocket
- store token ids for proper move/remove

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d86d47da48326a22006d051afe6a8