### PR TITLE
Add real-time board token sync

### DIFF
--- a/backend2/socketHandlers/lobby.js
+++ b/backend2/socketHandlers/lobby.js
@@ -54,7 +54,7 @@ export default function lobbyHandler(io, socket, prisma) {
   });
 
   // Присоединиться к лобби
-  socket.on('joinLobby', async ({ lobbyId }, cb) => {
+  socket.on('joinLobby', async ({ lobbyId }, cb = () => {}) => {
     const id = parseInt(lobbyId, 10);
     if (isNaN(id)) return cb({ error: 'Invalid lobbyId' });
 
@@ -62,9 +62,14 @@ export default function lobbyHandler(io, socket, prisma) {
       const lobby = await prisma.lobby.findUnique({ where: { id } });
       if (!lobby) return cb({ error: 'Lobby not found' });
 
-      await prisma.lobbyPlayer.create({
-        data: { lobbyId: id, userId: getUserId() },
-      });
+      try {
+        await prisma.lobbyPlayer.create({
+          data: { lobbyId: id, userId: getUserId() },
+        });
+      } catch (err) {
+        // Игнорируем ошибку уникальности, если игрок уже в лобби
+        if (err.code !== 'P2002') throw err;
+      }
 
       socket.join(roomName(id));
       cb({ lobbyId: id, name: lobby.name, masterId: lobby.masterId });

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -51,6 +51,16 @@
         <button id="deleteToken">Удалить токен</button>
         <button id="clearBoard">Очистить поле</button>
 
+        <div class="draw-section">
+          <h4>Рисование</h4>
+          <input type="color" id="drawColor" value="#ff0000" />
+          <input type="number" id="brushSize" value="4" min="1" max="50" />
+          <button id="brushTool">Кисть</button>
+          <button id="eraserTool">Ластик</button>
+          <button id="undoDraw">Назад</button>
+          <button id="redoDraw">Вперед</button>
+        </div>
+
         <div id="mapControls" class="map-section">
           <h4>Карты</h4>
           <input type="file" id="mapFile" accept="image/*" style="display:none" />

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -55,6 +55,7 @@
           <h4>Рисование</h4>
           <input type="color" id="drawColor" value="#ff0000" />
           <input type="number" id="brushSize" value="4" min="1" max="50" />
+          <button id="pointerTool">Курсор</button>
           <button id="brushTool">Кисть</button>
           <button id="eraserTool">Ластик</button>
           <button id="undoDraw">Назад</button>

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -50,6 +50,13 @@
         <!-- Кнопки управления токенами -->
         <button id="deleteToken">Удалить токен</button>
         <button id="clearBoard">Очистить поле</button>
+
+        <div id="mapControls" class="map-section">
+          <h4>Карты</h4>
+          <input type="file" id="mapFile" accept="image/*" style="display:none" />
+          <button id="uploadMap">Загрузить карту</button>
+          <div id="mapList"></div>
+        </div>
       </aside>
 
       <!-- Центральная игровая доска -->

--- a/frontend/src/chat.js
+++ b/frontend/src/chat.js
@@ -5,10 +5,10 @@ export function initChat(socket, lobbyId, chatBox, chatInput, sendBtn) {
 
   // 0) Входим в комнату лобби, чтобы получать real-time новые сообщения
   if (socket.connected) {
-    socket.emit('joinLobby', { lobbyId });
+    socket.emit('joinLobby', { lobbyId }, () => {});
   } else {
     socket.once('connect', () => {
-      socket.emit('joinLobby', { lobbyId });
+      socket.emit('joinLobby', { lobbyId }, () => {});
     });
   }
 

--- a/frontend/src/game.js
+++ b/frontend/src/game.js
@@ -73,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
     canvasAPI,
     socket,
     lobbyId,
+    pointerTool:     document.getElementById('pointerTool'),
     brushTool:        document.getElementById('brushTool'),
     eraserTool:       document.getElementById('eraserTool'),
     drawColorInput:   document.getElementById('drawColor'),

--- a/frontend/src/game/canvas.js
+++ b/frontend/src/game/canvas.js
@@ -1,11 +1,16 @@
 let canvas, ctx;
 let baseCellSize = 30;
 let scale = 1;
-let offsetX = 0, offsetY = 0;
-let isDragging = false, startX, startY;
+let offsetX = 0,
+  offsetY = 0;
+let isDragging = false,
+  startX,
+  startY;
 let selectedToken = null;
 let movingToken = null;
 let tokens = [];
+let maps = [];
+let moveCb = null;
 
 export function initCanvas(canvasElement) {
   canvas = canvasElement;
@@ -23,11 +28,20 @@ export function initCanvas(canvasElement) {
   // Возвращаем API для UI-контролов
   return {
     addToken,
+    addTokenWorld,
+    removeToken,
     removeSelectedToken,
     clearBoard,
     setTokens,
     getSelectedToken,
+    getTokens,
     setSelectedToken,
+    updateTokenPosition,
+    screenToWorld,
+    onTokenMove,
+    addMapWorld,
+    removeMap,
+    updateMapTransform,
   };
 }
 
@@ -47,9 +61,7 @@ export function setSelectedToken(token) {
 
 export function removeSelectedToken() {
   if (!selectedToken) return;
-  tokens = tokens.filter((t) => t !== selectedToken);
-  selectedToken = null;
-  draw();
+  removeToken(selectedToken.id);
 }
 
 export function clearBoard() {
@@ -58,14 +70,85 @@ export function clearBoard() {
   draw();
 }
 
-// Принимает экранные координаты, конвертирует в координаты сетки
-export function addToken(screenX, screenY, color, radius, image = null) {
-  const x = (screenX - offsetX) / scale;
-  const y = (screenY - offsetY) / scale;
-  const token = { x, y, color, radius, image };
+export function screenToWorld(screenX, screenY) {
+  return {
+    x: (screenX - offsetX) / scale,
+    y: (screenY - offsetY) / scale,
+  };
+}
+
+export function addTokenWorld(x, y, color, radius, imageSrc = null, id) {
+  const token = { id, x, y, color, radius, image: null };
+  if (imageSrc) {
+    const img = new Image();
+    img.src = imageSrc;
+    token.image = img;
+    img.onload = draw;
+  }
   tokens.push(token);
   draw();
+  return token;
 }
+
+export function addToken(screenX, screenY, color, radius, imageEl = null, id) {
+  const { x, y } = screenToWorld(screenX, screenY);
+  const src = imageEl?.src;
+  return addTokenWorld(x, y, color, radius, src, id);
+}
+
+export function updateTokenPosition(id, x, y) {
+  const tok = tokens.find((t) => t.id === id);
+  if (tok) {
+    tok.x = x;
+    tok.y = y;
+    draw();
+  }
+}
+
+export function removeToken(id) {
+  tokens = tokens.filter((t) => t.id !== id);
+  if (selectedToken && selectedToken.id === id) selectedToken = null;
+  draw();
+}
+
+export function getTokens() {
+  return tokens;
+}
+
+export function onTokenMove(cb) {
+  moveCb = cb;
+}
+
+// === Map helpers ===
+export function addMapWorld(url, id, x = 0, y = 0, mapScale = 1) {
+  const img = new Image();
+  const map = { id, x, y, scale: mapScale, image: img };
+  img.src = url;
+  img.onload = draw;
+  maps.push(map);
+  draw();
+  return map;
+}
+
+export function updateMapTransform(id, x, y, mapScale) {
+  const m = maps.find((mm) => mm.id === id);
+  if (!m) return;
+  if (typeof x === 'number') m.x = x;
+  if (typeof y === 'number') m.y = y;
+  if (typeof mapScale === 'number') m.scale = mapScale;
+  draw();
+}
+
+export function removeMap(id) {
+  maps = maps.filter((m) => m.id !== id);
+  draw();
+}
+
+export function getMaps() {
+  return maps;
+}
+
+// === Internal helpers ===
 
 function resizeCanvas() {
   canvas.width = window.innerWidth * 0.7;
@@ -132,6 +215,9 @@ function handleMouseMove(event) {
 
 function handleMouseUp() {
   isDragging = false;
+  if (movingToken) {
+    moveCb && moveCb(movingToken);
+  }
   movingToken = null;
 }
 
@@ -145,6 +231,7 @@ function getMousePos(event) {
 function draw() {
   if (!ctx) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawMaps();
   drawGrid();
   drawTokens();
 }
@@ -213,5 +300,17 @@ function drawTokens() {
     ctx.restore();
   });
 
+  ctx.restore();
+}
+
+function drawMaps() {
+  ctx.save();
+  ctx.translate(offsetX, offsetY);
+  ctx.scale(scale, scale);
+  maps.forEach((m) => {
+    if (m.image.complete) {
+      ctx.drawImage(m.image, m.x, m.y, m.image.width * m.scale, m.image.height * m.scale);
+    }
+  });
   ctx.restore();
 }

--- a/frontend/src/game/tokenManager.js
+++ b/frontend/src/game/tokenManager.js
@@ -1,4 +1,4 @@
-import { addToken as addCanvasToken } from "./canvas.js";
+
 
 let selectedImage = null;
 let isAddingToken = false;
@@ -8,6 +8,9 @@ export function initTokenManager({
   gallery,
   categorySelect,
   sizeSelect,
+  socket,
+  lobbyId,
+  canvasAPI,
 }) {
   galleryElement = gallery;
 
@@ -28,6 +31,8 @@ export function initTokenManager({
 
   return {
     isAddingToken: () => isAddingToken,
+    startAddingToken: () => { isAddingToken = true; },
+    setImage: src => { selectedImage = new Image(); selectedImage.src = src; },
     finalizeToken: () => {
       selectedImage = null;
       isAddingToken = false;
@@ -36,7 +41,23 @@ export function initTokenManager({
     createTokenAt: (x, y) => {
       const defaultColor = "#000"; // Используем чёрный по умолчанию вместо отсутствующего селектора цвета
       const radius = parseInt(sizeSelect.value, 10);
-      addCanvasToken(x, y, defaultColor, radius, selectedImage);
+      const { x: boardX, y: boardY } = canvasAPI.screenToWorld(x, y);
+      socket.emit(
+        "placeToken",
+        {
+          lobbyId,
+          resourceId: selectedImage?.src,
+          x: boardX,
+          y: boardY,
+          radius,
+          color: defaultColor,
+        },
+        (res) => {
+          if (res?.error) {
+            console.error("placeToken", res.error);
+          }
+        }
+      );
     },
   };
 }

--- a/frontend/src/game/uiControls.js
+++ b/frontend/src/game/uiControls.js
@@ -9,6 +9,7 @@ export function initUIControls({
   canvasAPI,
   socket,
   lobbyId,
+  pointerTool,
   brushTool,
   eraserTool,
   drawColorInput,
@@ -41,6 +42,11 @@ export function initUIControls({
       socket.emit("removeToken", { lobbyId, id: t.id }, () => {});
     });
     canvasAPI.clearBoard();
+  });
+
+  pointerTool.addEventListener('click', () => {
+    canvasAPI.setDrawingMode(false);
+    canvasAPI.setEraser(false);
   });
 
   brushTool.addEventListener('click', () => {

--- a/frontend/src/game/uiControls.js
+++ b/frontend/src/game/uiControls.js
@@ -9,6 +9,12 @@ export function initUIControls({
   canvasAPI,
   socket,
   lobbyId,
+  brushTool,
+  eraserTool,
+  drawColorInput,
+  brushSizeInput,
+  undoDrawBtn,
+  redoDrawBtn,
 }) {
   console.log("initUIControls initialized", { deleteTokenBtn, clearBoardBtn, canvasAPI, tokenManager });
 
@@ -35,6 +41,32 @@ export function initUIControls({
       socket.emit("removeToken", { lobbyId, id: t.id }, () => {});
     });
     canvasAPI.clearBoard();
+  });
+
+  brushTool.addEventListener('click', () => {
+    canvasAPI.setDrawingMode(true);
+    canvasAPI.setEraser(false);
+  });
+
+  eraserTool.addEventListener('click', () => {
+    canvasAPI.setDrawingMode(true);
+    canvasAPI.setEraser(true);
+  });
+
+  drawColorInput.addEventListener('change', () => {
+    canvasAPI.setBrushColor(drawColorInput.value);
+  });
+
+  brushSizeInput.addEventListener('change', () => {
+    canvasAPI.setBrushSize(parseInt(brushSizeInput.value, 10) || 1);
+  });
+
+  undoDrawBtn.addEventListener('click', () => {
+    socket.emit('undoStroke', { lobbyId }, () => {});
+  });
+
+  redoDrawBtn.addEventListener('click', () => {
+    socket.emit('redoStroke', { lobbyId }, () => {});
   });
 
   // Смена размера токена


### PR DESCRIPTION
## Summary
- extend backend game handler so placed tokens carry radius & color
- revamped canvas module with token add/update/remove helpers and move callbacks
- token manager now notifies server when placing tokens
- UI controls remove tokens via server and clear board for everyone
- game client loads initial board state and listens for token updates from the server
- pass `canvasAPI` into token manager so screen-to-world conversion works
- avoid duplicate local token on placement by relying on server event
- allow map uploads with per-map scale and removal by the lobby master
- canvas draws uploaded maps under the grid and tokens
- map list shows each map with scaling and delete controls
- hide map file input and trigger file selection from upload button
- check S3 configuration before uploading maps

## Testing
- `npm test` in `backend2` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_684d8eb89be88326837948cb20aa14dd